### PR TITLE
ci: npm install/ciに--ignore-scriptsを追加

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           cd web
-          npm install
+          npm install --ignore-scripts
           npm run build
 
       - name: Deploy 🚀


### PR DESCRIPTION
## Summary

- `npm ci` / `npm install` コマンドに `--ignore-scripts` フラグを追加
- サプライチェーン攻撃（TanStack等の事例）への緩和策として、CI/CDでのlifecycle script実行を無効化

## Background

npmパッケージが侵害された場合、`postinstall` 等のlifecycle scriptを通じて悪意あるコードが `npm install` 時に自動実行されるリスクがある。`--ignore-scripts` を付与することで、この経路での攻撃を防止できる。

## Test plan

- [ ] ワークフローが正常に実行されることを確認
- [ ] ビルド成果物に問題がないことを確認
- [ ] `postinstall` スクリプトに依存している場合は別途対応が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)