### PR TITLE
chore: npm install → npm ci --ignore-scripts

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           cd web
-          npm install --ignore-scripts
+          npm ci --ignore-scripts
           npm run build
 
       - name: Deploy 🚀


### PR DESCRIPTION
## Summary

GitHub Actionsワークフローのnpmコマンドを改善します。

- `npm install` → `npm ci`: lockfileを厳密に再現し、サプライチェーン攻撃のリスクを軽減
- `--ignore-scripts`: postinstallスクリプトの自動実行を防止

参考: https://qiita.com/masato_makino/items/516ca6f8a8b497131602