### PR TITLE
fix(ci): Actionsのセキュリティチェックの指摘を修正

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,12 +3,17 @@ name: Build and Deploy
 on:
   push:
     branches: ["master"]
+permissions: {}
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install and Build 🔧
         run: |


### PR DESCRIPTION
## 概要

zizmor（GitHub Actionsワークフローの静的解析ツール）で org 全体を点検した結果検出された、GitHub Pagesデプロイワークフローのセキュリティ指摘を修正しました。

## 修正前後の findings 件数

- 修正前: 2件（artipacked 1, excessive-permissions 1）
- 修正後: 0件

## 修正内容

- **excessive-permissions**: 権限の指定がなく、リポジトリのデフォルト設定（GITHUB_TOKENに書き込み権限あり）に依存していたため、明示的に `permissions: {}` をワークフロー冒頭に置き、デプロイジョブには `gh-pages` ブランチへの push に必要な `contents: write` のみを付与しました。
- **artipacked**: `actions/checkout` に `persist-credentials: false` を追加しました。デプロイに使用している `JamesIves/github-pages-deploy-action` は checkout の資格情報を使わず、GITHUB_TOKEN（既定値）を使って自前で認証を行う仕組みのため、checkout側の資格情報を永続化する必要はありません。

## 保留にした指摘

なし。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)