### PR TITLE
chore(ci): GitHub Pages の配信を公式 Action 方式へ移行

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,28 +1,59 @@
 name: Build and Deploy
+
+# GitHub Pages への配信。gh-pages ブランチを経由せず、公式 Action で
+# ビルド成果物を直接 Pages へ渡す。
+#
+# 前提: リポジトリ設定 Settings → Pages → Source が "GitHub Actions" であること。
+# "Deploy from a branch" のままだと、このワークフローは成功しても公開内容が
+# 更新されない（古い gh-pages の内容が配信され続ける）。
 # 作業ブランチへの push で本番へ配信されないよう、対象を既定ブランチに限定する
 on:
   push:
     branches: ["master"]
 permissions: {}
+
+# 配信が同時に走らないよう直列化する
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      # configure-pages が Pages サイトの情報を取得するために必要
+      pages: read
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v7
         with:
+          # 配信は artifact 経由で行うため、checkout の資格情報は使わない
           persist-credentials: false
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
       - name: Install and Build 🔧
         run: |
           cd web
           npm ci --ignore-scripts
           npm run build
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          branch: gh-pages
-          folder: web/build
+          path: web/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write      # Pages へ配信する
+      id-token: write   # 配信元を検証する OIDC トークンの発行
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 何をする PR か

GitHub Pages への配信を **gh-pages ブランチ経由から公式 Action 方式へ**移行します。

```diff
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@<SHA>
-        with:
-          branch: gh-pages
-          folder: <出力先>
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      ...
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: <出力先>
+
+  deploy:
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v5
```

**ビルド手順は一切変えていません。**

## なぜ

| 観点 | 現状 | 移行後 |
|---|---|---|
| 依存 | サードパーティ Action（個人アカウント提供） | **GitHub 公式のみ** |
| 必要な権限 | `contents: write` | `pages: read/write` + `id-token: write` |
| gh-pages ブランチ | 必要 | **不要** |

`contents: write` はリポジトリの内容を書き換えられる強い権限です。公式方式なら Pages への配信権限だけで足ります。

CALIL org ではこの2方式が **10 : 11** で混在しており、公式方式へ寄せていく方針です。

## ⚠️ マージ後に設定変更が必要

**Settings → Pages → Source を `GitHub Actions` に変更**します（現在は `Deploy from a branch`）。古いままだとワークフローは成功するのに公開内容が更新されません。マージ時に私が API で切り替え、サイトが実際に更新されるところまで確認します。

## 先に `littel-ui` で検証済み

同じ変更を [`littel-ui` #19](https://github.com/CALIL/littel-ui/pull/19) で先に実施し、**build / deploy 両ジョブ success・新しいデプロイ記録・サイト正常** を確認しています。そこで分かった注意点を最初から反映しました。

- `configure-pages` には **`pages: read` が必要**（`contents: read` だけでは `Resource not accessible by integration` で失敗）
- ジョブを `build` / `deploy` に分け、権限をそれぞれ最小化
- `concurrency` で配信の同時実行を防止

## そのほか

- ジョブ名を `build-and-deploy` → `build` に変更（`deploy` ジョブと並ぶため）
- `workflow_dispatch` は付けていません（既存のトリガーを変えないため）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
