### PR TITLE
chore: ruff の安全な自動修正を当てる

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 import serial
 import cv2
@@ -102,7 +101,7 @@ def initialize_camera(cap, role):
 
     if IS_NEW4K:
         # しばらく低解像度をデータ取得した後に、高解像度に切り替える
-        cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, float(0.25))
+        cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, 0.25)
         cap.set(cv2.CAP_PROP_EXPOSURE, float(-6))
         cap.set(cv2.CAP_PROP_FPS, 15)
         cap.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
@@ -132,21 +131,21 @@ def initialize_camera(cap, role):
         cap.set(cv2.CAP_PROP_BRIGHTNESS, 0 if IS_NEW4K else -50)
         cap.set(cv2.CAP_PROP_GAMMA, 110 if IS_NEW4K else 150)
         if IS_NEW4K:
-            cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, float(0.25))
+            cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, 0.25)
             cap.set(cv2.CAP_PROP_EXPOSURE, float(-7))
     elif role == "SIDE":
         cap.set(cv2.CAP_PROP_FOCUS, 235 if IS_NEW4K else 95)  # フォーカス設定
         cap.set(cv2.CAP_PROP_BRIGHTNESS, 0 if IS_NEW4K else -100)
         cap.set(cv2.CAP_PROP_GAMMA, 110 if IS_NEW4K else 110)
         if IS_NEW4K:
-            cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, float(0.25))
+            cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, 0.25)
             cap.set(cv2.CAP_PROP_EXPOSURE, float(-7))
     elif role == "TOP":
         cap.set(cv2.CAP_PROP_FOCUS, 200 if IS_NEW4K else 77)  # フォーカス設定
         cap.set(cv2.CAP_PROP_BRIGHTNESS, 0 if IS_NEW4K else -40)
         cap.set(cv2.CAP_PROP_GAMMA, 110 if IS_NEW4K else 130)
         if IS_NEW4K:
-            cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, float(0.25))
+            cap.set(cv2.CAP_PROP_AUTO_EXPOSURE, 0.25)
             cap.set(cv2.CAP_PROP_EXPOSURE, float(-6))
     else:
         cap.set(cv2.CAP_PROP_FOCUS, 200 if IS_NEW4K else 70)


### PR DESCRIPTION
ruff 0.16.3 の**安全な自動修正だけ**を当てた（`ruff check --fix`、unsafe な修正は適用していない）。

**修正 5件**: `UP018:4 UP009:1`

**検証**: 変更した Python ファイル 1件のうち、**0件は AST が完全に一致**する（パース結果が変わらないことを機械的に確認した）。残る 1件は差分を目で見て確認した。全ファイルが構文エラー無しでパースできる。


このリポジトリは pyproject.toml を持たず、README も Anaconda の Python 3.7 を前提に書かれている。そのため **target-version は ruff の既定（py39）のまま**にし、`select` の追加も見送った。当てたのは `float(0.25)` を `0.25` にする4件と、先頭の coding 宣言の削除1件だけで、どの Python 3 でも等価。

横断調査（active な Python リポジトリ70件・指摘2769件）の一環。
